### PR TITLE
Update mod4-credential.json

### DIFF
--- a/tools/deploy/module4/mod4-credential.json
+++ b/tools/deploy/module4/mod4-credential.json
@@ -1,7 +1,7 @@
 {    
     "name": "gha-mod4-oidc",
     "issuer": "https://token.actions.githubusercontent.com",
-    "subject": "repo:msmarti/AKS-DevSecOps-Workshop:environment:test",
+    "subject": "repo:<your-github-username>/AKS-DevSecOps-Workshop:environment:test",
     "audiences": ["api://AzureADTokenExchange"],
     "description": "Workload Identity for AKS DevSecOps repo - Mod 4"
 }


### PR DESCRIPTION
replaced specific repository name with a generic github username to adhere to the guide description.